### PR TITLE
Scoreモデルを追加

### DIFF
--- a/app/models/score.rb
+++ b/app/models/score.rb
@@ -1,0 +1,2 @@
+class Score < ApplicationRecord
+end

--- a/db/migrate/20171116093611_create_scores.rb
+++ b/db/migrate/20171116093611_create_scores.rb
@@ -1,0 +1,10 @@
+class CreateScores < ActiveRecord::Migration[5.1]
+  def change
+    create_table :scores do |t|
+      t.string :username
+      t.integer :score
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,22 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 20171116093611) do
+
+  create_table "scores", force: :cascade do |t|
+    t.string "username"
+    t.integer "score"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+end

--- a/test/fixtures/scores.yml
+++ b/test/fixtures/scores.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  username: MyString
+  score: 1
+
+two:
+  username: MyString
+  score: 1

--- a/test/models/score_test.rb
+++ b/test/models/score_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class ScoreTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 概要

スコアを管理するためのモデルを追加した。
カラムは、username(string)と、score(integer)である。
実行したコマンドは以下。

`$ bundle exec rails g model score username:string score:integer`
`$ bundle exec rake db:create`
`$ bundle exec rake db:migrate`

## 背景

モデルがなかった